### PR TITLE
Issue #15 - Run Signature Test from maven also on JDK 11

### DIFF
--- a/com.ibm.jbatch.tck.dist.exec/pom.xml
+++ b/com.ibm.jbatch.tck.dist.exec/pom.xml
@@ -227,7 +227,15 @@
                         <configuration>
                             <skip>${skipSigTests}</skip>
                             <target>
-                                <property name="java.base.sigtest.path" value="${java.home}/lib/rt.jar" />
+                                <available property="java.base.sigtest.path.rt.jar.present" file="${java.home}/lib/rt.jar"/>
+                                <condition property="java.base.sigtest.path" value="${java.home}/lib/rt.jar">
+                                    <istrue value="${java.base.sigtest.path.rt.jar.present}"/>
+                                </condition>
+                                <condition property="java.base.sigtest.path" value="jdk-modules/java.base">
+                                    <isfalse value="${java.base.sigtest.path.rt.jar.present}"/>
+                                </condition>
+                                <ant dir="${dist.exec.antdir}" antfile="sigtest.build.xml" target="extractJdkModulesIfNeeded" />
+
                                 <property name="sigtestdev.classes" value="${project.build.directory}/executeTCK/runSigTest/sigtestdev.jar" />
                                 <property name="batch.impl.sigtest.path" value="${jbatch.runtime.dir}/jakarta.batch-api.jar${ps}${jbatch.runtime.dir}/com.ibm.jbatch.container.jar${ps}${jbatch.runtime.dir}/com.ibm.jbatch.spi.jar${ps}${jbatch.runtime.dir}/jakarta.inject-api.jar${ps}${jbatch.runtime.dir}/jakarta.enterprise.cdi-api.jar" />
                                 <ant dir="${dist.exec.antdir}" antfile="sigtest.build.xml" target="runSigTest" />

--- a/com.ibm.jbatch.tck.dist.exec/pom.xml
+++ b/com.ibm.jbatch.tck.dist.exec/pom.xml
@@ -183,10 +183,6 @@
                         </goals>
                         <configuration>
                             <rules>
-                                <requireJavaVersion>
-                                    <version>[1.8,1.9)</version>
-                                    <message>${nl}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!${nl}! This execution must be run with Java 8 (since signature test ${nl}config out of the box only works with Java 8).${nl}If you add '-DskipSigTests=true' you can run the TestNG runtime${nl}  tests with Java 11.  Or set up -Djava.base.sigtest.path to run with Java 11, and run with -Denforcer.skip or remove this enforcer check. ${nl} It's just to give a more obvious failure and keep people thinking they did something wrong.${nl}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!${nl}</message>
-                                </requireJavaVersion>
                                 <requireProperty>
                                     <property>java.vendor</property>
                                     <message>IBM JDK cannot be used for signature tests.</message>

--- a/com.ibm.jbatch.tck/sigtest/sigtest.build.xml
+++ b/com.ibm.jbatch.tck/sigtest/sigtest.build.xml
@@ -53,6 +53,16 @@
         </sigtest>
     </target>
 
+    <target name="extractJdkModulesIfNeeded" description="If rt.jar isn't available, extracts the JDK 9+ modules so that they can be added to the classpath"
+        unless="java.base.sigtest.path.rt.jar.present">
+        <property name="executable-full-path"
+          location="${java.home}/bin/jimage"/>
+          <exec executable="${executable-full-path}">
+              <arg value="extract"/>
+              <arg value="--dir=jdk-modules"/>
+              <arg value="${java.home}/lib/modules"/>
+          </exec>
+    </target>
 </project>
 
 

--- a/jakarta.batch.official.tck/pom.xml
+++ b/jakarta.batch.official.tck/pom.xml
@@ -136,6 +136,7 @@
                 <configuration>
                     <sourceDocumentName>batch-tck-reference-guide.adoc</sourceDocumentName>
                     <sourceHighlighter>coderay</sourceHighlighter>
+                    <skip>${asciidoc.skip}</skip>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Fixes #15:

* Detects whether `rt.jar` is present in the JDK and, if not, extracts the `java.base` module from the JDK and uses it instead
* Removes the Java version enforcer rule, it was only needed because sigtests didn't run on Java 8 out of the box
* Not related, but also adds a property to disable running the generation of PDF and HTML guides by Asciidoc, which is lengthy and not needed most of the time

To run the signature tests, run the following command in the root of this repository with both Java 8 and Java 11:

```
mvn install -DskipTests
```