### PR TITLE
remove unmatched '-->' from arquillian.xml

### DIFF
--- a/jakarta.batch.arquillian.exec/src/test/resources/arquillian.xml
+++ b/jakarta.batch.arquillian.exec/src/test/resources/arquillian.xml
@@ -59,7 +59,6 @@ SPDX-License-Identifier: Apache-2.0 -->
     </configuration>
   </container>
 
-  -->
   <container qualifier="liberty-managed">
     <configuration>
        <property name="wlpHome">target/liberty/wlp</property>


### PR DESCRIPTION
arquillian.xml contains an unmatched '-->' comment end-marker, which makes the xml invalid.