### PR TITLE
Fixes dependencies in the Arquillian parent project

### DIFF
--- a/jakarta.batch.arquillian.exec-parent/pom.xml
+++ b/jakarta.batch.arquillian.exec-parent/pom.xml
@@ -31,51 +31,32 @@ Copyright 2012, 2022 International Business Machines Corp. and others
     <packaging>pom</packaging>
     <name>Jakarta Batch Arquillian TCK Execution Parent</name>
 
-    <dependencies>
-        <dependency>
-            <groupId>jakarta.batch</groupId>
-            <artifactId>com.ibm.jbatch.tck</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.batch</groupId>
-            <artifactId>com.ibm.jbatch.tck.appbean</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.batch</groupId>
-            <artifactId>jakarta.batch.arquillian.extension</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-container-test-spi</artifactId>
-            <version>1.7.0.Alpha9</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.junit5</groupId>
-            <artifactId>arquillian-junit5-core</artifactId>
-            <version>1.7.0.Alpha9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.junit5</groupId>
-            <artifactId>arquillian-junit5-container</artifactId>
-            <version>1.7.0.Alpha9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>jakarta.batch.reporting</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.30</version>
-        </dependency>
-    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian.container</groupId>
+                <artifactId>arquillian-container-test-spi</artifactId>
+                <version>1.7.0.Alpha9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.junit5</groupId>
+                <artifactId>arquillian-junit5-core</artifactId>
+                <version>1.7.0.Alpha9</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.junit5</groupId>
+                <artifactId>arquillian-junit5-container</artifactId>
+                <version>1.7.0.Alpha9</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-jdk14</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/jakarta.batch.arquillian.exec/pom.xml
+++ b/jakarta.batch.arquillian.exec/pom.xml
@@ -50,30 +50,25 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-test-spi</artifactId>
-            <version>1.7.0.Alpha9</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-core</artifactId>
-            <version>1.7.0.Alpha9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>1.7.0.Alpha9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>jakarta.batch</groupId>
             <artifactId>jakarta.batch.reporting</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.30</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,12 @@
                 <version>${batch.tck.version}</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.batch</groupId>
+                <artifactId>jakarta.batch.reporting</artifactId>
+                <version>${batch.tck.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.ibm.jbatch</groupId>
                 <artifactId>com.ibm.jbatch.container</artifactId>
                 <version>${batch.impl.version}</version>
@@ -436,9 +442,9 @@
                     <version>${version.org.codehaus.mojo.properties-maven-plugin}</version>
                 </plugin>
                 <plugin>
-                  <groupId>org.netbeans.tools</groupId>
-                  <artifactId>sigtest-maven-plugin</artifactId>
-                  <version>${version.org.netbeans.tools.sigtest-maven-plugin}</version>
+                    <groupId>org.netbeans.tools</groupId>
+                    <artifactId>sigtest-maven-plugin</artifactId>
+                    <version>${version.org.netbeans.tools.sigtest-maven-plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Parent should define them in dependency management so that children can override them or exclude them.
Parent shouldn't define dependencies based on project's group or artifact ID or version. These will be derived from the children's project properties and cannot be redefined, leading to non-existing artifact definitions.