### PR TITLE
upgrade jakarta.ejb-api from 4.0.0 to 4.0.1

### DIFF
--- a/jakarta.batch.tck.util/pom.xml
+++ b/jakarta.batch.tck.util/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>jakarta.ejb</groupId>
             <artifactId>jakarta.ejb-api</artifactId>
-            <version>4.0.0</version>
+            <version>4.0.1</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
jakarta.ejb-api 4.0.1 is the official release for Jakarta EE 10.